### PR TITLE
docs: Update specs for Sense/Act API wiring (#886)

### DIFF
--- a/docs/specs/03-mcp-server.md
+++ b/docs/specs/03-mcp-server.md
@@ -80,8 +80,9 @@ Takes no parameters.
 | `metadata.soul_name` | Soul display name |
 | `metadata.model_recommendation` | Suggested LLM model (`claude-sonnet-4-6`) |
 | `metadata.cache_guidance` | Hints for prompt caching — `system_prompt` is stable; `snapshot` is semi-stable |
-| `capability_tools` | Array of `{ name, description }` for `act`-type capabilities registered by connected Bridges |
+| `capability_tools` | Array of `{ name, description }` for `act`-type capabilities registered by connected Bridges. Each capability also has a corresponding `act_*` MCP tool registered dynamically on the server (see below). |
 | `recent_nodes` | Up to 5 recently activated memory nodes as plain text |
+| `pending_senses` | _(optional)_ Array of unprocessed sense events from `sense_log`. Present only when there are unprocessed rows. Each entry includes `id`, `capability_id`, `bridge_id`, `data`, `created_at`. Rows are marked `processed=true` immediately after being returned. |
 
 ---
 
@@ -241,6 +242,31 @@ Returns the current datetime in the specified timezone.
 ```json
 { "datetime": "2026/04/14（火） 16:30:00", "iso": "2026-04-14T07:30:00.000Z", "timezone": "Asia/Tokyo" }
 ```
+
+---
+
+### `act_*` — Dynamic Act Tools
+
+When `createMcpServer` is initialized, it queries the `capabilities` table for `act`-type capabilities belonging to **currently connected** Bridges. For each matching capability, a tool is registered dynamically:
+
+- **Tool name**: `act_${cap.name.toLowerCase().replace(/[^a-z0-9]/g, '_')}`
+- **Description**: capability's `description` field (or `"<name> を実行する"` as fallback)
+- **Parameters**:
+
+  | Parameter | Type | Required | Description |
+  |-----------|------|----------|-------------|
+  | `action` | `string` | ✅ | Action to execute. When `config.actions` is set, valid values are listed in the description. |
+  | `parameters` | `object` | — | Action-specific key-value payload |
+  | `timeout_ms` | `number` | — | Timeout in milliseconds (default: 5000) |
+
+**Execution flow:**
+1. If the Bridge is connected → delegates to `handleActTool()` → result returned as JSON.
+2. If the Bridge is **not** connected → queues the action in `act_queue` with `status='pending'`. Returns:
+   ```json
+   { "queue_id": "<uuid>", "status": "pending", "message": "Bridge is not connected. Action queued for later execution." }
+   ```
+
+These tools are not listed in `capability_tools` (which is a plain-object summary for the LLM client); they are fully registered as callable MCP tools on the server.
 
 ---
 

--- a/docs/specs/06-sense-act-bridge.md
+++ b/docs/specs/06-sense-act-bridge.md
@@ -183,7 +183,38 @@ Content-Type: application/json
 
 ## Sense Input via REST
 
-Besides the WebSocket `sense` message, external systems can push sense events via REST:
+### POST `/v1/beings/:being_id/sense`
+
+Push sense data from external clients (game engines, HTTP-only devices, etc.) without a WebSocket connection.
+
+```
+POST /v1/beings/:being_id/sense
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "capability_id": "cap-camera-001",
+  "data": {
+    "image_url": "https://...",
+    "timestamp": "2026-04-17T12:00:00Z"
+  }
+}
+```
+
+- `capability_id` must exist in the `capabilities` table with `type='sense'` and belong to the authenticated user. Invalid IDs return `400`.
+- `data` is stored as-is in `sense_log`. Any JSON object is accepted.
+- The `processed` flag is initially `false`; it is flipped to `true` when `get_context` fetches the row.
+
+**Response (201):**
+```json
+{
+  "sense_id": "<uuid>",
+  "capability_id": "cap-camera-001",
+  "processed": false
+}
+```
+
+### GET `/v1/beings/:being_id/sense/history`
 
 ```
 GET /v1/beings/:being_id/sense/history
@@ -234,6 +265,69 @@ Returns only capabilities from **currently connected** (online) Bridges:
   ]
 }
 ```
+
+---
+
+## Act Queue — Pending / Approve / Reject
+
+When the MCP client calls an `act_*` tool but the Bridge is **not connected**, the action is queued in `act_queue` with `status='pending'` instead of being sent immediately.
+
+External clients can inspect and resolve queued actions via REST:
+
+### GET `/v1/beings/:being_id/act/pending`
+
+```
+GET /v1/beings/:being_id/act/pending
+Authorization: Bearer <token>
+```
+
+Returns all actions waiting for Bridge execution:
+
+```json
+{
+  "actions": [
+    {
+      "id": "<uuid>",
+      "capability_id": "cap-speaker-001",
+      "bridge_id": "my-phone-bridge",
+      "action_type": "play",
+      "action_payload": { "url": "https://..." },
+      "status": "pending",
+      "created_at": "2026-04-17T12:00:00Z"
+    }
+  ]
+}
+```
+
+### POST `/v1/beings/:being_id/act/pending/approve`
+
+Mark a queued action as approved (user or Bridge confirms execution):
+
+```
+POST /v1/beings/:being_id/act/pending/approve
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{ "action_id": "<uuid>" }
+```
+
+Updates `act_queue.status` to `'approved'` and sets `resolved_at`. Returns `{ ok: true, action: { ... } }`.
+
+### POST `/v1/beings/:being_id/act/pending/reject`
+
+Reject a queued action:
+
+```
+POST /v1/beings/:being_id/act/pending/reject
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{ "action_id": "<uuid>" }
+```
+
+Updates `act_queue.status` to `'rejected'` and sets `resolved_at`. Returns `{ ok: true, action: { ... } }`.
+
+> **Note:** Automatic execution of approved actions when the Bridge reconnects is out of scope for this release and will be addressed in a follow-up issue.
 
 ---
 


### PR DESCRIPTION
## 概要

ruddia #886 の実装に合わせて、beingリポのspecを更新。

## 変更内容

### docs/specs/06-sense-act-bridge.md
- **POST `/v1/beings/:being_id/sense`** セクションを追加
  - WebSocketなしでsense入力を受け付けるHTTPエンドポイント
  - `capability_id` のバリデーション（capabilitiesテーブル存在確認）
- **Act Queue REST endpoints** セクションを追加
  - `GET /v1/beings/:being_id/act/pending` — pending一覧
  - `POST /v1/beings/:being_id/act/pending/approve` — 承認
  - `POST /v1/beings/:being_id/act/pending/reject` — 拒否

### docs/specs/03-mcp-server.md
- `get_context` レスポンスに `pending_senses` フィールドを追記
- **`act_*` Dynamic Act Tools** セクションを追加
  - ツール名規則: `act_${cap.name.toLowerCase().replace(/[^a-z0-9]/g, '_')}`
  - Bridge接続中/不在の挙動（接続中: 即時実行、不在: act_queueにqueueing）

## 関連
- ruddia PR: wnbhr/ruddia#887