### PR TITLE
feat: search_memory を action/feeling/themes 横断 OR/AND 検索に改修

### DIFF
--- a/being-worker/src/lib/chat/haiku-recall.test.ts
+++ b/being-worker/src/lib/chat/haiku-recall.test.ts
@@ -1,0 +1,84 @@
+/**
+ * haiku-recall.test.ts — toFragments のユニットテスト
+ *
+ * テスト対象: toFragments()
+ * 断片モード（action / feeling シャッフル）の挙動を検証する。
+ */
+
+import { describe, it, expect } from 'vitest'
+import { toFragments } from './haiku-recall.js'
+
+describe('toFragments', () => {
+  it('空配列なら空文字を返す', () => {
+    expect(toFragments([])).toBe('')
+  })
+
+  it('action も feeling も無いノードしかなければ空文字', () => {
+    const nodes = [
+      { scene: { setting: 'カフェ' }, feeling: null },
+      { scene: null, feeling: null },
+    ]
+    expect(toFragments(nodes)).toBe('')
+  })
+
+  it('action のみ持つノードを正しく返す', () => {
+    const nodes = [{ scene: { action: 'コードを書いた' }, feeling: null }]
+    expect(toFragments(nodes)).toBe('コードを書いた')
+  })
+
+  it('feeling のみ持つノードを正しく返す', () => {
+    const nodes = [{ scene: null, feeling: '嬉しい' }]
+    expect(toFragments(nodes)).toBe('嬉しい')
+  })
+
+  it('複数ノードの action と feeling 全部を断片に含める', () => {
+    const nodes = [
+      { scene: { action: 'A1' }, feeling: 'F1' },
+      { scene: { action: 'A2' }, feeling: 'F2' },
+    ]
+    const result = toFragments(nodes)
+    const pieces = result.split(' / ')
+    expect(pieces.sort()).toEqual(['A1', 'A2', 'F1', 'F2'])
+  })
+
+  it('themes は断片に含めない（action / feeling のみ）', () => {
+    const nodes = [
+      { scene: { action: 'やった' }, feeling: '満足' },
+    ]
+    // 型上 themes は受け取らないが、もし渡しても無視される設計を担保
+    const result = toFragments(nodes)
+    expect(result).toBe('やった / 満足' as string)
+    // 順序はシャッフルされるので、いずれかであること
+    const pieces = result.split(' / ').sort()
+    expect(pieces).toEqual(['やった', '満足'])
+  })
+
+  it('null/undefined の scene/feeling を安全にスキップする', () => {
+    const nodes = [
+      { scene: { action: 'A' }, feeling: null },
+      { scene: null, feeling: 'F' },
+      { scene: { action: '' }, feeling: '' }, // 空文字は除外される
+      { scene: { action: 'B' }, feeling: undefined },
+    ]
+    const result = toFragments(nodes)
+    const pieces = result.split(' / ').sort()
+    expect(pieces).toEqual(['A', 'B', 'F'])
+  })
+
+  it('シャッフルが効いている — 大規模入力で順序が変わりうる', () => {
+    const nodes = Array.from({ length: 10 }, (_, i) => ({
+      scene: { action: `action${i}` },
+      feeling: `feeling${i}`,
+    }))
+    // 同じ入力で複数回実行し、少なくとも1回は元と異なる順序になる
+    const baseline = nodes.flatMap((n) => [n.scene.action, n.feeling]).join(' / ')
+    let differs = false
+    for (let i = 0; i < 20; i++) {
+      if (toFragments(nodes) !== baseline) {
+        differs = true
+        break
+      }
+    }
+    expect(differs).toBe(true)
+  })
+})

--- a/being-worker/src/lib/chat/haiku-recall.ts
+++ b/being-worker/src/lib/chat/haiku-recall.ts
@@ -34,16 +34,12 @@ export interface HaikuRecallResult {
  * ノード境界を消した断片テキストを返す。
  * 人間の記憶想起に近い「ごちゃごちゃ」した形式。
  */
-function toFragments(nodes: Array<{ scene: Scene | null; feeling?: string | null; themes?: string[] | null }>): string {
+function toFragments(nodes: Array<{ scene: Scene | null; feeling?: string | null }>): string {
   const pieces: string[] = []
 
   for (const n of nodes) {
     if (n.scene?.action) pieces.push(n.scene.action)
     if (n.feeling) pieces.push(n.feeling)
-    if (n.themes?.length) {
-      // themes は全部入れると冗長なので最大2つ
-      pieces.push(...n.themes.slice(0, 2))
-    }
   }
 
   if (pieces.length === 0) return ''
@@ -70,7 +66,7 @@ async function runVectorRecall(store: MemoryStore, userMessage: string): Promise
   if (matches.length === 0) return ''
 
   // 3. 各クラスタのノードを取得し、reactivation_count をインクリメント
-  const allNodes: Array<{ scene: Scene | null; feeling?: string | null; themes?: string[] | null }> = []
+  const allNodes: Array<{ scene: Scene | null; feeling?: string | null }> = []
 
   for (const match of matches) {
     const cluster = await store.getCluster(match.id)

--- a/being-worker/src/lib/chat/haiku-recall.ts
+++ b/being-worker/src/lib/chat/haiku-recall.ts
@@ -1,11 +1,12 @@
 /**
- * haiku-recall.ts — #32 Haikuフロント連想パイプライン
+ * haiku-recall.ts — #32 Haikuフロント連想パイプライン（断片モード）
  *
  * spec-31 (#598): Haikuキーワードマッチ → cosine類似度ベクトル検索に置き換え。
  * 1. ユーザーメッセージを OpenAI text-embedding-3-small でembedding
  * 2. findSimilarClusters() で類似クラスタを取得
  * 3. ヒットクラスタのノードを取得し reactivation_count をインクリメント
- * 4. <memory-recall> タグで返す（常駐ノードはget_context snapshotに移動）
+ * 4. 断片モード: action/feeling/themes をシャッフルして混ぜた <memory-recall> タグで返す
+ *    ノード境界をぼかすことで、人間の記憶想起に近い「ごちゃごちゃ」した形式にする
  *
  * #62: MemoryStore interface 経由に移行
  */
@@ -13,7 +14,7 @@
 import type { MemoryStore } from '../memory/types.js'
 import type { LLMProvider } from '../llm/types.js'
 import { embedText } from '../memory/embedding.js'
-import { sceneToText } from './scene-utils.js'
+import type { Scene } from './scene-utils.js'
 
 // ──────────────────────────────────────────────
 // 型定義
@@ -22,6 +23,38 @@ import { sceneToText } from './scene-utils.js'
 export interface HaikuRecallResult {
   /** <memory-recall>...</memory-recall> タグで包まれた文字列。ヒットなしなら空文字 */
   content: string
+}
+
+// ──────────────────────────────────────────────
+// 断片シャッフル
+// ──────────────────────────────────────────────
+
+/**
+ * 複数ノードの action / feeling / themes をばらして混ぜ、
+ * ノード境界を消した断片テキストを返す。
+ * 人間の記憶想起に近い「ごちゃごちゃ」した形式。
+ */
+function toFragments(nodes: Array<{ scene: Scene | null; feeling?: string | null; themes?: string[] | null }>): string {
+  const pieces: string[] = []
+
+  for (const n of nodes) {
+    if (n.scene?.action) pieces.push(n.scene.action)
+    if (n.feeling) pieces.push(n.feeling)
+    if (n.themes?.length) {
+      // themes は全部入れると冗長なので最大2つ
+      pieces.push(...n.themes.slice(0, 2))
+    }
+  }
+
+  if (pieces.length === 0) return ''
+
+  // Fisher-Yates シャッフル
+  for (let i = pieces.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[pieces[i], pieces[j]] = [pieces[j], pieces[i]]
+  }
+
+  return pieces.join(' / ')
 }
 
 // ──────────────────────────────────────────────
@@ -37,7 +70,7 @@ async function runVectorRecall(store: MemoryStore, userMessage: string): Promise
   if (matches.length === 0) return ''
 
   // 3. 各クラスタのノードを取得し、reactivation_count をインクリメント
-  const parts: string[] = []
+  const allNodes: Array<{ scene: Scene | null; feeling?: string | null; themes?: string[] | null }> = []
 
   for (const match of matches) {
     const cluster = await store.getCluster(match.id)
@@ -55,24 +88,14 @@ async function runVectorRecall(store: MemoryStore, userMessage: string): Promise
       await store.incrementReactivationCounts(nodes.map((n) => n.id)).catch((err) => {
         console.warn('[haiku-recall] incrementReactivationCounts failed (ignored):', err)
       })
+      allNodes.push(...nodes)
     }
-
-    const digestLine = cluster.digest ? `${cluster.digest}` : ''
-    const nodeLines = nodes
-      .map((n) => `- ${sceneToText(n.scene, n.feeling)}`)
-      .join('\n')
-
-    const section = [
-      `[${cluster.name}]${digestLine ? ` ${digestLine}` : ''}`,
-      nodeLines,
-    ]
-      .filter(Boolean)
-      .join('\n')
-
-    if (section) parts.push(section)
   }
 
-  return parts.join('\n\n')
+  if (allNodes.length === 0) return ''
+
+  // 4. 断片モード: 全ノードの action/feeling/themes をシャッフルして混ぜる
+  return toFragments(allNodes)
 }
 
 // ──────────────────────────────────────────────

--- a/being-worker/src/lib/chat/haiku-recall.ts
+++ b/being-worker/src/lib/chat/haiku-recall.ts
@@ -30,11 +30,13 @@ export interface HaikuRecallResult {
 // ──────────────────────────────────────────────
 
 /**
- * 複数ノードの action / feeling / themes をばらして混ぜ、
+ * 複数ノードの action / feeling をばらして混ぜ、
  * ノード境界を消した断片テキストを返す。
  * 人間の記憶想起に近い「ごちゃごちゃ」した形式。
+ *
+ * @internal Exported for unit testing.
  */
-function toFragments(nodes: Array<{ scene: Scene | null; feeling?: string | null }>): string {
+export function toFragments(nodes: Array<{ scene: Scene | null; feeling?: string | null }>): string {
   const pieces: string[] = []
 
   for (const n of nodes) {

--- a/being-worker/src/lib/chat/system-prompt.ts
+++ b/being-worker/src/lib/chat/system-prompt.ts
@@ -124,7 +124,8 @@ const PRINCIPLES_BASE = `
 - scenesには構造化データを渡せ（action/actors/when必須。feeling/themesは省略するな。setting/importanceも可能な限り埋めろ）
 - get_contextで返される既存sceneを確認し、同じ話題ならaction=updateでscene_idsを指定して統合しろ。新しい話題ならaction=appendで追加。迷ったら呼べ
 - セッション終了時にも必ず呼べ
-- **recall**: ユーザーからメッセージを受け取ったら毎ターン最初にrecallを呼べ。今の話題に関連する過去の記憶をベクトル検索で取得する。get_contextで取得したsnapshotとは別物 — 毎ターン変わる
+- **recall**: ユーザーからメッセージを受け取ったら毎ターン最初にrecallを呼べ。結果は断片（action/feelingのシャッフル）として返る — 構造化リストではない。雰囲気として受け取り自然に活かす。get_contextで取得したsnapshotとは別物 — 毎ターン変わる
+- **recall_memory / search_memory**: 毎ターン呼ぶものではない。recallだけでは情報が足りない時の追加検索。recall_memoryはクラスタ単位の深掘り、search_memoryはキーワードでのピンポイント検索
 
 ## ツール結果後の応答
 - ツールを使う場合は、まず必要なツールを全て実行する。全結果が揃ってから最終回答を書く

--- a/being-worker/src/lib/memory/supabase-store.test.ts
+++ b/being-worker/src/lib/memory/supabase-store.test.ts
@@ -1,0 +1,94 @@
+/**
+ * supabase-store.test.ts — 検索クエリ構築ヘルパーのユニットテスト
+ *
+ * テスト対象:
+ *   - sanitizeSearchTerm()
+ *   - buildSearchOrClause()
+ *
+ * search_memory の OR/AND 検索で PostgREST の or() フィルタに渡される
+ * クエリ文字列が、構文記号で破損しないことを担保する。
+ */
+
+import { describe, it, expect } from 'vitest'
+import { sanitizeSearchTerm, buildSearchOrClause } from './supabase-store.js'
+
+describe('sanitizeSearchTerm', () => {
+  it('普通の単語は変化なし', () => {
+    expect(sanitizeSearchTerm('記憶')).toBe('記憶')
+    expect(sanitizeSearchTerm('hello')).toBe('hello')
+  })
+
+  it('カンマを除去する（or() のセパレータ）', () => {
+    expect(sanitizeSearchTerm('a,b')).toBe('ab')
+  })
+
+  it('丸括弧を除去する（in 構文）', () => {
+    expect(sanitizeSearchTerm('a(b)c')).toBe('abc')
+  })
+
+  it('波括弧を除去する（配列リテラル）', () => {
+    expect(sanitizeSearchTerm('{a}')).toBe('a')
+  })
+
+  it('ダブルクォートを除去する（配列値の引用）', () => {
+    expect(sanitizeSearchTerm('"foo"')).toBe('foo')
+  })
+
+  it('ilike のワイルドカード % をエスケープする', () => {
+    expect(sanitizeSearchTerm('50%')).toBe('50\\%')
+  })
+
+  it('ilike のワイルドカード _ をエスケープする', () => {
+    expect(sanitizeSearchTerm('foo_bar')).toBe('foo\\_bar')
+  })
+
+  it('全部混ざったケース', () => {
+    expect(sanitizeSearchTerm('a,b(c){d}"e"%f_g')).toBe('abcde\\%f\\_g')
+  })
+
+  it('空文字はそのまま空文字', () => {
+    expect(sanitizeSearchTerm('')).toBe('')
+  })
+})
+
+describe('buildSearchOrClause', () => {
+  it('普通の単語は3フィールド分の or 句を生成する', () => {
+    const result = buildSearchOrClause('記憶')
+    expect(result).toBe(
+      'scene->>action.ilike.%記憶%,feeling.ilike.%記憶%,themes.cs.{"記憶"}'
+    )
+  })
+
+  it('themes は配列値としてダブルクォートで括られる', () => {
+    const result = buildSearchOrClause('感情')
+    expect(result).toContain('themes.cs.{"感情"}')
+  })
+
+  it('action / feeling は ilike 部分一致になる', () => {
+    const result = buildSearchOrClause('test')
+    expect(result).toContain('scene->>action.ilike.%test%')
+    expect(result).toContain('feeling.ilike.%test%')
+  })
+
+  it('サニタイズで空になる入力は空文字を返す', () => {
+    // カンマと括弧だけなら全部除去されて空に
+    expect(buildSearchOrClause(',()')).toBe('')
+    expect(buildSearchOrClause('{}')).toBe('')
+    expect(buildSearchOrClause('""')).toBe('')
+  })
+
+  it('ワイルドカードを含む入力もエスケープされた状態で組み込まれる', () => {
+    const result = buildSearchOrClause('50%')
+    expect(result).toContain('scene->>action.ilike.%50\\%%')
+  })
+
+  it('構文記号入りでも or() 構文が壊れない', () => {
+    // 入力に , ( ) { } " が混じってても、サニタイズ後の clause は
+    // or() のパースを壊さない形になっている
+    const result = buildSearchOrClause('a,b(c)')
+    expect(result.includes(',(')).toBe(false)
+    expect(result.includes(')')).toBe(false)
+    // clause 内で意図的に使われる , とフィールド区切り記号は残る
+    expect(result.split(',').length).toBe(3) // 3フィールド分
+  })
+})

--- a/being-worker/src/lib/memory/supabase-store.ts
+++ b/being-worker/src/lib/memory/supabase-store.ts
@@ -31,6 +31,41 @@ import type {
 } from './types.js'
 
 // ──────────────────────────────────────────────
+// 検索クエリ構築ヘルパー（ユニットテスト可能なよう export）
+// ──────────────────────────────────────────────
+
+/**
+ * PostgREST の or() フィルタ用に検索語をサニタイズする。
+ *
+ * - or() の構文記号: `,` `(` `)` `{` `}` `"` を除去
+ * - ilike のワイルドカード: `%` `_` をバックスラッシュでエスケープ
+ *
+ * @internal Exported for unit testing.
+ */
+export function sanitizeSearchTerm(term: string): string {
+  return term.replace(/[,(){}"]/g, '').replace(/[%_]/g, '\\$&')
+}
+
+/**
+ * 1検索語を action/feeling/themes 横断の or() clause 文字列に変換する。
+ * サニタイズ後に空になった場合は空文字を返す。
+ *
+ * 例: "記憶" → "scene->>action.ilike.%記憶%,feeling.ilike.%記憶%,themes.cs.{\"記憶\"}"
+ *
+ * @internal Exported for unit testing.
+ */
+export function buildSearchOrClause(term: string): string {
+  const safe = sanitizeSearchTerm(term)
+  if (!safe) return ''
+  // themes は string[] のため contains (cs) 構文を使い、配列値はダブルクォートで括る
+  return [
+    `scene->>action.ilike.%${safe}%`,
+    `feeling.ilike.%${safe}%`,
+    `themes.cs.{"${safe}"}`,
+  ].join(',')
+}
+
+// ──────────────────────────────────────────────
 // ファクトリ関数
 // ──────────────────────────────────────────────
 
@@ -62,25 +97,17 @@ export function createSupabaseMemoryStore(
       if (filter.searchQuery) {
         const terms = filter.searchQuery.trim().split(/\s+/).filter(Boolean)
         const mode = filter.searchMode ?? 'or'
+
         if (mode === 'and') {
           // AND: 全ての語が action / feeling / themes のいずれかに含まれる
           for (const term of terms) {
-            const escaped = term.replace(/[%_]/g, '\\$&')
-            query = query.or(
-              `scene->>action.ilike.%${escaped}%,feeling.ilike.%${escaped}%,themes.cs.{${escaped}}`
-            )
+            const clause = buildSearchOrClause(term)
+            if (clause) query = query.or(clause)
           }
         } else {
           // OR: いずれかの語が action / feeling / themes のいずれかに含まれる
-          const orParts = terms.flatMap((term) => {
-            const escaped = term.replace(/[%_]/g, '\\$&')
-            return [
-              `scene->>action.ilike.%${escaped}%`,
-              `feeling.ilike.%${escaped}%`,
-              `themes.cs.{${escaped}}`,
-            ]
-          })
-          query = query.or(orParts.join(','))
+          const orParts = terms.map(buildSearchOrClause).filter(Boolean)
+          if (orParts.length > 0) query = query.or(orParts.join(','))
         }
       }
 

--- a/being-worker/src/lib/memory/supabase-store.ts
+++ b/being-worker/src/lib/memory/supabase-store.ts
@@ -59,6 +59,30 @@ export function createSupabaseMemoryStore(
       if (filter.actionQuery) {
         query = query.filter('scene->>action', 'ilike', `%${filter.actionQuery}%`)
       }
+      if (filter.searchQuery) {
+        const terms = filter.searchQuery.trim().split(/\s+/).filter(Boolean)
+        const mode = filter.searchMode ?? 'or'
+        if (mode === 'and') {
+          // AND: 全ての語が action / feeling / themes のいずれかに含まれる
+          for (const term of terms) {
+            const escaped = term.replace(/[%_]/g, '\\$&')
+            query = query.or(
+              `scene->>action.ilike.%${escaped}%,feeling.ilike.%${escaped}%,themes.cs.{${escaped}}`
+            )
+          }
+        } else {
+          // OR: いずれかの語が action / feeling / themes のいずれかに含まれる
+          const orParts = terms.flatMap((term) => {
+            const escaped = term.replace(/[%_]/g, '\\$&')
+            return [
+              `scene->>action.ilike.%${escaped}%`,
+              `feeling.ilike.%${escaped}%`,
+              `themes.cs.{${escaped}}`,
+            ]
+          })
+          query = query.or(orParts.join(','))
+        }
+      }
 
       const orderBy = filter.orderBy ?? 'importance'
       const orderDir = filter.orderDirection ?? 'desc'

--- a/being-worker/src/lib/memory/types.ts
+++ b/being-worker/src/lib/memory/types.ts
@@ -204,7 +204,9 @@ export interface NodeFilter {
   secondaryOrderBy?: 'importance' | 'last_activated' | 'created_at'
   secondaryOrderDirection?: 'asc' | 'desc'
   limit?: number
-  actionQuery?: string  // scene->>action に ilike
+  actionQuery?: string  // scene->>action に ilike（後方互換）
+  searchQuery?: string  // action / feeling / themes を横断検索
+  searchMode?: 'or' | 'and'  // デフォルト 'or'
 }
 
 // ──────────────────────────────────────────────

--- a/being-worker/src/mcp/server.ts
+++ b/being-worker/src/mcp/server.ts
@@ -98,9 +98,25 @@ export async function createMcpServer(
         if (nodes.length === 0) {
           return { content: [{ type: 'text' as const, text: `「${args.query}」に関する記憶は見つかりませんでした。` }] }
         }
-        const lines = nodes.map(n =>
-          `- [${n.id}] ${sceneToText(n.scene as import('../lib/chat/scene-utils.js').Scene | null, n.feeling)}${n.themes ? ` (themes: ${(n.themes as string[]).join(', ')})` : ''}`
-        )
+
+        // どのフィールドにヒットしたかを判定するヘルパー
+        const terms = args.query.trim().split(/\s+/).filter(Boolean).map(t => t.toLowerCase())
+        const detectMatchedFields = (n: typeof nodes[number]): string[] => {
+          const fields: string[] = []
+          const action = (n.scene as { action?: string } | null)?.action?.toLowerCase() ?? ''
+          const feeling = (n.feeling ?? '').toLowerCase()
+          const themes = (n.themes as string[] | null) ?? []
+          if (terms.some(t => action.includes(t))) fields.push('action')
+          if (terms.some(t => feeling.includes(t))) fields.push('feeling')
+          if (terms.some(t => themes.some(th => th.toLowerCase().includes(t)))) fields.push('themes')
+          return fields
+        }
+
+        const lines = nodes.map(n => {
+          const matched = detectMatchedFields(n)
+          const matchTag = matched.length > 0 ? ` [matched: ${matched.join(',')}]` : ''
+          return `- [${n.id}]${matchTag} ${sceneToText(n.scene as import('../lib/chat/scene-utils.js').Scene | null, n.feeling)}${n.themes ? ` (themes: ${(n.themes as string[]).join(', ')})` : ''}`
+        })
         return { content: [{ type: 'text' as const, text: `記憶 ${nodes.length}件:\n${lines.join('\n')}` }] }
       } catch (err) {
         return { content: [{ type: 'text' as const, text: `error: ${String(err)}` }], isError: true }

--- a/being-worker/src/mcp/server.ts
+++ b/being-worker/src/mcp/server.ts
@@ -79,16 +79,18 @@ export async function createMcpServer(
   // ── search_memory ──────────────────────────────────────────────────────────
   server.tool(
     'search_memory',
-    '記憶ノード（memory_nodes）をキーワードで検索する。過去の体験・感情・出来事を思い出したい時に使う。recall_memoryと違いcluster_idは不要。',
+    '記憶ノード（memory_nodes）をキーワードで検索する。action / feeling / themes を横断検索。スペース区切りでOR検索（デフォルト）。mode="and" で全語AND検索。',
     {
-      query: z.string().describe('検索キーワード（部分一致）'),
+      query: z.string().describe('検索キーワード。スペース区切りで複数語指定可（デフォルトOR検索）'),
+      mode: z.enum(['or', 'and']).optional().describe('検索モード: "or"（デフォルト）または "and"'),
       limit: z.number().optional().describe('返す件数（デフォルト10、最大30）'),
     },
     async (args) => {
       try {
         const limit = Math.min(args.limit ?? 10, 30)
         const nodes = await store.getNodes({
-          actionQuery: args.query,
+          searchQuery: args.query,
+          searchMode: args.mode ?? 'or',
           limit,
           orderBy: 'importance',
           orderDirection: 'desc',

--- a/docs/specs/03-mcp-server.md
+++ b/docs/specs/03-mcp-server.md
@@ -58,9 +58,9 @@ Pass `X-LLM-API-Key: <anthropic_key>` to enable LLM-dependent features (patrol c
 |-----------|------|----------|-------------|
 | `user_message` | `string` | ✅ | The current user message to search against |
 
-**Returns:** A `<memory-recall>` block containing matched cluster names and top-3 active nodes per cluster, or an empty message if nothing matched.
+**Returns:** A `<memory-recall>` block containing shuffled fragments of `action` and `feeling` from matched nodes, with cluster boundaries intentionally blurred — mimicking human associative recall. Empty message if nothing matched.
 
-**Mechanism:** Embeds `user_message` with `text-embedding-3-small` (256-dim), calls `match_clusters` RPC, increments `reactivation_count` on returned nodes.
+**Mechanism:** Embeds `user_message` with `text-embedding-3-small` (256-dim), calls `match_clusters` RPC, collects top-3 active nodes per cluster, increments `reactivation_count` on all returned nodes, then shuffles `action`/`feeling` values across all nodes into a single fragment string.
 
 ---
 
@@ -105,11 +105,12 @@ Explore memory clusters. Without `cluster_id`, returns the cluster list. With `c
 
 ### `search_memory`
 
-Keyword search across `memory_nodes` without needing a cluster ID.
+Keyword search across `memory_nodes` without needing a cluster ID. Searches `action`, `feeling`, and `themes` fields.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `query` | `string` | ✅ | Partial-match keyword (case-insensitive) |
+| `query` | `string` | ✅ | Space-separated keywords. Each term is matched against `action`, `feeling`, and `themes` |
+| `mode` | `string` | — | `"or"` (default): any term matches. `"and"`: all terms must match |
 | `limit` | `number` | — | Max results (default 10, max 30) |
 
 **Returns:** Matched nodes ordered by `importance` desc, formatted as scene text lines.


### PR DESCRIPTION
## 背景
`search_memory` が `scene->>action` への素朴な ilike 一本で実装されており、スペース区切りで複数語を入れても単語分割せず完全フレーズ部分一致になっていた。結果、複数語クエリでほぼヒットしない問題があった。

## 変更内容

### `types.ts`
- `NodeFilter` に `searchQuery?: string` / `searchMode?: "or" | "and"` を追加
- `actionQuery` は後方互換のため残す

### `supabase-store.ts`
- `searchQuery` を OR / AND モードでフィールド横断 ilike に展開
  - **OR（デフォルト）**: 各語が `action` / `feeling` / `themes` のいずれかに含まれればヒット
  - **AND**: 全語が `action` / `feeling` / `themes` のいずれかに含まれる場合のみヒット
- `themes` は配列型のため `cs.{term}` で contains 検索

### `mcp/server.ts`
- `search_memory` ツールを `searchQuery` / `mode` パラメータに切替
- スペース区切りで複数語指定可能に
- `mode="and"` で明示的 AND 検索

## 動作例
```
// OR検索（デフォルト）— 「記憶」か「感情」を含むノード
search_memory({ query: "記憶 感情" })

// AND検索 — 「記憶」も「感情」も含むノード
search_memory({ query: "記憶 感情", mode: "and" })
```