### PR TITLE
docs(#937, #938): update Scene.when to WhenItem + expand reactivation table

### DIFF
--- a/docs/specs/04-memory-and-patrol.md
+++ b/docs/specs/04-memory-and-patrol.md
@@ -55,11 +55,23 @@ A scene is stored as a JSONB object. The canonical fields are:
 interface Scene {
   action: string      // What happened (required — primary clustering key)
   actors: string[]    // Who was involved (required)
-  when: string[]      // Dates as YYYY-MM-DD (required)
+  when: WhenItem[]    // Timeline entries (required). See WhenItem below.
   setting?: string    // Where / context
   dialogue?: string[] // Notable quotes
   sensory?: string[]  // Sensory details
 }
+
+/**
+ * WhenItem — timeline entry in a scene.
+ *
+ * Two forms are supported (backward-compatible):
+ *   - string: a plain date string "YYYY-MM-DD" (original format)
+ *   - object: { date: "YYYY-MM-DD", action: "summary of what happened that day" }
+ *
+ * The object form is written by the consolidation step (❹) so that the history
+ * of absorbed nodes is preserved rather than discarded.
+ */
+type WhenItem = string | { date: string; action: string }
 ```
 
 The `feeling` field is stored separately alongside the scene (a top-level column), not inside the JSONB object.
@@ -172,7 +184,15 @@ RPC `revive_dead_nodes` — checks all `dead` nodes. A node is revived to `activ
 ```
 eff_imp = importance × exp(−session_count / 30) > 0.05
 ```
-This condition can be satisfied after `recall` increments `reactivation_count` (by +1 via `recall` tool, or by +2 when browsing via `recall_memory`).
+This condition can be satisfied after `reactivation_count` is incremented by any of the following:
+
+| Tool | Nodes affected | Increment |
+|---|---|---|
+| `recall` | active nodes returned by vector search | +1 |
+| `recall_memory` | active nodes in the cluster | +1 |
+| `recall_memory` | dead nodes in the cluster | +2 (aggressive revival signal) |
+| `search_memory` | active nodes matching the query | +1 |
+| `search_memory` | dead nodes matching the query | +2 |
 
 #### ❻ Cluster splitting — LLM required (Sonnet)
 
@@ -235,4 +255,4 @@ Every time `recall` is called (either via MCP or internally during chat):
 
 If no clusters match, the tool returns an empty result (no tag).
 
-When `recall_memory` is called explicitly with a `cluster_id`, dead nodes in the result have their `reactivation_count` incremented by 2 (more aggressive revival signal).
+When `recall_memory` is called explicitly with a `cluster_id`, nodes in the result have their `reactivation_count` incremented: dead nodes by +2 (aggressive revival signal), active nodes by +1. Similarly, `search_memory` increments active nodes by +1 and dead nodes by +2 for all matching results.


### PR DESCRIPTION
## Overview

OSS spec update corresponding to ruddia PRs #940 (#937) and #939 (#938).

## Changes — `docs/specs/04-memory-and-patrol.md`

### `Scene.when` type — WhenItem (backward-compatible)

**Before:**
```typescript
when: string[]  // Dates as YYYY-MM-DD
```

**After:**
```typescript
when: WhenItem[]

// WhenItem = string | { date: string; action: string }
// - string: original format, still accepted
// - object: written by consolidation (❹) to preserve absorbed node history
```

When two similar nodes are consolidated, the survivor's `when` array now stores `{date, action}` entries so the history of what happened on each date is not lost.

### Reactivation table — all tools now documented

**Before:** only mentioned `recall` (+1) and `recall_memory` dead nodes (+2).

**After:** full table covering all three tools:

| Tool | Nodes | Increment |
|---|---|---|
| `recall` | active | +1 |
| `recall_memory` | active | +1 ← new |
| `recall_memory` | dead | +2 |
| `search_memory` | active | +1 ← new |
| `search_memory` | dead | +2 ← new |
