### PR TITLE
feat: ノードレベルベクトル検索（recall / recall_memory / search_memory）

### DIFF
--- a/being-worker/src/lib/chat/graph.ts
+++ b/being-worker/src/lib/chat/graph.ts
@@ -18,7 +18,7 @@ import type { MemoryStore, MemoryNode } from '../memory/types.js'
 import type { LLMProvider } from '../llm/types.js'
 import type { Scene } from './scene-utils.js'
 import type { SceneInput } from './update-notes.js'
-import { embedTexts, recomputeClusterVector } from '../memory/embedding.js'
+import { embedTexts, recomputeClusterVector, nodeToEmbedText } from '../memory/embedding.js'
 
 // ──────────────────────────────────────────────
 // 型定義
@@ -242,11 +242,17 @@ async function step1_saveAndAssignNodes(store: MemoryStore, apiKey?: string): Pr
 
   const nodeIds = await store.saveNodes(nodePayloads)
 
-  // action を一括 embedding（OpenAI API 1回）
+  // when+action+feeling を一括 embedding（OpenAI API 1回）— spec-946
   const actions = valid.map(({ sceneInput }) => sceneInput.action)
+  const embedTextsInput = valid.map(({ sceneInput }) =>
+    nodeToEmbedText(
+      { when: sceneInput.when, action: sceneInput.action } as Scene,
+      sceneInput.feeling ?? null
+    )
+  )
   let embeddings: number[][] = []
   try {
-    embeddings = await embedTexts(actions)
+    embeddings = await embedTexts(embedTextsInput)
   } catch (err) {
     console.warn('[graph] ❶ embedTexts failed, skipping cluster assignment:', err)
   }
@@ -295,6 +301,20 @@ async function step1_saveAndAssignNodes(store: MemoryStore, apiKey?: string): Pr
   for (const clusterId of affectedClusterIds) {
     await recomputeClusterVector(store, clusterId).catch((err) => {
       console.warn('[graph] ❶ recomputeClusterVector failed:', clusterId, err)
+    })
+  }
+
+  // ノードvectorをDBに保存（spec-946: ノードレベルベクトル検索用）
+  const nodeVectorUpdates: Array<{ id: string; vector: number[] }> = []
+  for (let i = 0; i < nodeIds.length; i++) {
+    const nodeId = nodeIds[i]
+    if (nodeId && embeddings[i]) {
+      nodeVectorUpdates.push({ id: nodeId, vector: embeddings[i] })
+    }
+  }
+  if (nodeVectorUpdates.length > 0) {
+    await store.updateNodeVectors(nodeVectorUpdates).catch((err) => {
+      console.warn('[graph] ❶ updateNodeVectors failed (ignored):', err)
     })
   }
 

--- a/being-worker/src/lib/chat/haiku-recall.ts
+++ b/being-worker/src/lib/chat/haiku-recall.ts
@@ -32,47 +32,30 @@ async function runVectorRecall(store: MemoryStore, userMessage: string): Promise
   // 1. ユーザーメッセージを embed
   const queryVector = await embedText(userMessage)
 
-  // 2. 類似クラスタを検索
-  const matches = await store.findSimilarClusters(queryVector)
-  if (matches.length === 0) return ''
+  // 2. 類似ノードを直接検索（spec-946: クラスタレベル → ノードレベル）
+  const nodeMatches = await store.findSimilarNodes(queryVector, 3, 0.35)
+  if (nodeMatches.length === 0) return ''
 
-  // 3. 各クラスタのノードを取得し、reactivation_count をインクリメント
-  const parts: string[] = []
+  // 3. ヒットノードを取得し、reactivation_count をインクリメント
+  const nodeIds = nodeMatches.map((m) => m.id)
+  const nodes = await store.getNodesByIds(nodeIds)
 
-  for (const match of matches) {
-    const cluster = await store.getCluster(match.id)
-    if (!cluster) continue
-
-    const nodes = await store.getNodes({
-      clusterId: match.id,
-      status: 'active',
-      orderBy: 'importance',
-      orderDirection: 'desc',
-      limit: 3,
+  if (nodes.length > 0) {
+    await store.incrementReactivationCounts(nodes.map((n) => n.id)).catch((err) => {
+      console.warn('[haiku-recall] incrementReactivationCounts failed (ignored):', err)
     })
-
-    if (nodes.length > 0) {
-      await store.incrementReactivationCounts(nodes.map((n) => n.id)).catch((err) => {
-        console.warn('[haiku-recall] incrementReactivationCounts failed (ignored):', err)
-      })
-    }
-
-    const digestLine = cluster.digest ? `${cluster.digest}` : ''
-    const nodeLines = nodes
-      .map((n) => `- ${sceneToText(n.scene, n.feeling)}`)
-      .join('\n')
-
-    const section = [
-      `[${cluster.name}]${digestLine ? ` ${digestLine}` : ''}`,
-      nodeLines,
-    ]
-      .filter(Boolean)
-      .join('\n')
-
-    if (section) parts.push(section)
   }
 
-  return parts.join('\n\n')
+  const parts: string[] = []
+  for (const match of nodeMatches) {
+    const node = nodes.find((n) => n.id === match.id)
+    if (!node) continue
+    const line = sceneToText(node.scene, node.feeling)
+    // node_id / cluster_id を深掘り用に含める
+    parts.push(`- ${line} [node_id: ${node.id}${node.cluster_id ? `, cluster_id: ${node.cluster_id}` : ''}]`)
+  }
+
+  return parts.join('\n')
 }
 
 // ──────────────────────────────────────────────

--- a/being-worker/src/lib/chat/recall-tools.ts
+++ b/being-worker/src/lib/chat/recall-tools.ts
@@ -21,16 +21,16 @@ import { recomputeClusterVector } from '../memory/embedding.js'
 export const RECALL_MEMORY_TOOL = {
   name: 'recall_memory',
   description:
-    '指定したクラスタの記憶ダイジェストとノードを取得する。通常の会話ではHaikuフロントで自動注入されるが、特定のクラスタを深掘りしたい時に使う。',
+    '指定したクラスタまたはノードの記憶を取得する。cluster_id指定: クラスタ内ノード一覧。node_id指定: 特定ノードの詳細。recallツールが返したcluster_id/node_idを使って深掘りするユースケース。',
   input_schema: {
     type: 'object',
     properties: {
       cluster_id: { type: 'string', description: 'クラスタID（UUID）' },
+      node_id: { type: 'string', description: 'ノードID（UUID）— 指定時はそのノードの詳細を返す' },
       limit: { type: 'number', description: '返すノード数（デフォルト5）' },
       query: { type: 'string', description: 'ノード絞り込み用キーワード（action/dialogueにilike検索、省略可）' },
       no_nodes: { type: 'boolean', description: 'trueでdigestのみ返す' },
     },
-    required: ['cluster_id'],
   },
 } as const
 
@@ -56,8 +56,26 @@ export const MERGE_NODES_TOOL = {
 
 export async function handleRecallMemory(
   store: MemoryStore,
-  input: { cluster_id: string; limit?: number; query?: string; no_nodes?: boolean }
+  input: { cluster_id?: string; node_id?: string; limit?: number; query?: string; no_nodes?: boolean }
 ): Promise<string> {
+  // node_id 指定: 特定ノードの詳細を返す（spec-946）
+  if (input.node_id && !input.cluster_id) {
+    const nodes = await store.getNodesByIds([input.node_id])
+    const node = nodes[0]
+    if (!node) return `ノード ${input.node_id} は見つかりませんでした`
+    const lines = [
+      `[ノード: ${node.id}]`,
+      `action: ${node.scene?.action ?? '（なし）'}`,
+      `feeling: ${node.feeling ?? '（なし）'}`,
+      `themes: ${node.themes?.join(', ') ?? '（なし）'}`,
+      `importance: ${node.importance ?? '—'}`,
+      `cluster_id: ${node.cluster_id ?? '（なし）'}`,
+    ]
+    return lines.join('\n')
+  }
+
+  if (!input.cluster_id) return 'cluster_id または node_id を指定してください'
+
   // 1. クラスタを取得
   const cluster = await store.getCluster(input.cluster_id)
 

--- a/being-worker/src/lib/memory/embedding.ts
+++ b/being-worker/src/lib/memory/embedding.ts
@@ -9,7 +9,7 @@
 
 const OPENAI_EMBEDDING_URL = 'https://api.openai.com/v1/embeddings'
 const EMBEDDING_MODEL = 'text-embedding-3-small'
-const EXPECTED_DIM = 256
+const EXPECTED_DIM = 1536
 
 // ──────────────────────────────────────────────
 // 単一テキスト embed
@@ -28,7 +28,8 @@ export async function embedText(text: string): Promise<number[]> {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${apiKey}`,
     },
-    body: JSON.stringify({ model: EMBEDDING_MODEL, input: text, dimensions: EXPECTED_DIM }),
+    body: JSON.stringify({ model: EMBEDDING_MODEL, input: text }),
+    // dimensions パラメータ削除: 1536 はモデルデフォルト
   })
 
   if (!response.ok) {
@@ -65,7 +66,8 @@ export async function embedTexts(texts: string[]): Promise<number[][]> {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${apiKey}`,
     },
-    body: JSON.stringify({ model: EMBEDDING_MODEL, input: texts, dimensions: EXPECTED_DIM }),
+    body: JSON.stringify({ model: EMBEDDING_MODEL, input: texts }),
+    // dimensions パラメータ削除: 1536 はモデルデフォルト
   })
 
   if (!response.ok) {
@@ -106,10 +108,23 @@ export function averageVectors(vectors: number[][]): number[] {
 // ──────────────────────────────────────────────
 
 import type { MemoryStore } from './types.js'
+import type { Scene } from '../chat/scene-utils.js'
 
 /**
- * クラスタ内全activeノードのaction textをembedし、平均ベクトルでクラスタを更新する。
+ * ノードのwhen + action + feelingを結合してembedテキストを生成する。
+ * spec-946: embed対象をactionのみ→ when+action+feelingに拡張
+ */
+export function nodeToEmbedText(scene: Scene, feeling: string | null): string {
+  const when = scene.when?.length ? `[${scene.when.join(', ')}] ` : ''
+  const action = scene.action || ''
+  const feel = feeling ? ` / ${feeling}` : ''
+  return `${when}${action}${feel}`
+}
+
+/**
+ * クラスタ内全activeノードをembedし、平均ベクトルでクラスタを更新する。
  * OPENAI_API_KEY がない、またはノードが0件の場合はスキップ（warningのみ）。
+ * spec-946: embed対象を action のみ → nodeToEmbedText(when+action+feeling) に変更
  */
 export async function recomputeClusterVector(
   store: MemoryStore,
@@ -121,13 +136,13 @@ export async function recomputeClusterVector(
   }
 
   const nodes = await store.getNodes({ clusterId, status: 'active' })
-  const actions = nodes
-    .map((n) => n.scene?.action)
-    .filter((a): a is string => typeof a === 'string' && a.trim().length > 0)
+  const texts = nodes
+    .filter((n) => n.scene?.action && n.scene.action.trim().length > 0)
+    .map((n) => nodeToEmbedText(n.scene as Scene, n.feeling))
 
-  if (actions.length === 0) return
+  if (texts.length === 0) return
 
-  const vectors = await embedTexts(actions)
+  const vectors = await embedTexts(texts)
   const avg = averageVectors(vectors)
   await store.updateClusterVector(clusterId, avg)
 }

--- a/being-worker/src/lib/memory/supabase-store.ts
+++ b/being-worker/src/lib/memory/supabase-store.ts
@@ -209,9 +209,49 @@ export function createSupabaseMemoryStore(
         query_embedding: queryVector,
         match_threshold: threshold,
         match_count: topK,
+        ...(beingId ? { p_being_id: beingId } : {}),
       })
       if (error) throw new Error(`findSimilarClusters failed: ${error.message}`)
       return (data as Array<{ id: string; name: string; similarity: number }> | null) ?? []
+    },
+
+    async findSimilarNodes(
+      queryVector: number[],
+      topK = 5,
+      threshold = 0.35
+    ): Promise<Array<{ id: string; cluster_id: string | null; similarity: number }>> {
+      const { data, error } = await supabase.rpc('match_nodes', {
+        p_user_id: userId,
+        query_embedding: queryVector,
+        match_threshold: threshold,
+        match_count: topK,
+        ...(beingId ? { p_being_id: beingId } : {}),
+      })
+      if (error) throw new Error(`findSimilarNodes failed: ${error.message}`)
+      return (data as Array<{ id: string; cluster_id: string | null; similarity: number }> | null) ?? []
+    },
+
+    async updateNodeVector(nodeId: string, vector: number[]): Promise<void> {
+      const { error } = await supabase
+        .from('memory_nodes')
+        .update({ vector })
+        .eq('id', nodeId)
+        .eq('user_id', userId)
+      if (error) throw new Error(`updateNodeVector failed: ${error.message}`)
+    },
+
+    async updateNodeVectors(updates: Array<{ id: string; vector: number[] }>): Promise<void> {
+      // 一件ずつ更新（Supabaseは一括 upsertでvectorを上書きできるが、id+user_id の複合キーのため小分けで実行）
+      for (const { id, vector } of updates) {
+        const { error } = await supabase
+          .from('memory_nodes')
+          .update({ vector })
+          .eq('id', id)
+          .eq('user_id', userId)
+        if (error) {
+          console.warn(`[supabase-store] updateNodeVectors: failed for node ${id}:`, error.message)
+        }
+      }
     },
 
     async updateCluster(clusterId: string, updates: Partial<Pick<Cluster, 'name' | 'digest' | 'parent_id' | 'vector' | 'is_parent'>>): Promise<void> {

--- a/being-worker/src/lib/memory/types.ts
+++ b/being-worker/src/lib/memory/types.ts
@@ -248,6 +248,12 @@ export interface MemoryStore {
   reviveDeadNodes(): Promise<number>
   /** cosine類似度でクラスタを検索（spec-31）。OPENAI_API_KEYがない場合は空配列を返す */
   findSimilarClusters(queryVector: number[], topK?: number, threshold?: number): Promise<Array<{ id: string; name: string; similarity: number }>>
+  /** cosine類似度でノードを検索（spec-946 match_nodes RPC）*/
+  findSimilarNodes(queryVector: number[], topK?: number, threshold?: number): Promise<Array<{ id: string; cluster_id: string | null; similarity: number }>>
+  /** ノードのvectorを更新（spec-946）*/
+  updateNodeVector(nodeId: string, vector: number[]): Promise<void>
+  /** ノードのvectorを一括更新（spec-946）*/
+  updateNodeVectors(updates: Array<{ id: string; vector: number[] }>): Promise<void>
 
 
 

--- a/being-worker/src/mcp/server.ts
+++ b/being-worker/src/mcp/server.ts
@@ -77,14 +77,34 @@ export function createMcpServer(
   // ── search_memory ──────────────────────────────────────────────────────────
   server.tool(
     'search_memory',
-    '記憶ノード（memory_nodes）をキーワードで検索する。過去の体験・感情・出来事を思い出したい時に使う。recall_memoryと違いcluster_idは不要。',
+    '記憶ノード（memory_nodes）をベクトル検索する。過去の体験・感情・出来事を思い出したい時に使う。recall_memoryと違いcluster_idは不要。OPENAI_API_KEY未設定時はキーワード検索にフォールバック。',
     {
-      query: z.string().describe('検索キーワード（部分一致）'),
+      query: z.string().describe('検索クエリ（ベクトル検索またはキーワード部分一致）'),
       limit: z.number().optional().describe('返す件数（デフォルト10、最大30）'),
     },
     async (args) => {
       try {
         const limit = Math.min(args.limit ?? 10, 30)
+
+        // ベクトル検索（OPENAI_API_KEY必須）— spec-946
+        if (process.env.OPENAI_API_KEY) {
+          const { embedText } = await import('../lib/memory/embedding.js')
+          const queryVector = await embedText(args.query)
+          const nodeMatches = await store.findSimilarNodes(queryVector, limit, 0.35)
+          if (nodeMatches.length > 0) {
+            const nodeIds = nodeMatches.map((m) => m.id)
+            const nodes = await store.getNodesByIds(nodeIds)
+            const lines = nodeMatches.map((m) => {
+              const node = nodes.find((n) => n.id === m.id)
+              if (!node) return null
+              return `- [node_id: ${node.id}${node.cluster_id ? `, cluster_id: ${node.cluster_id}` : ''}] ${sceneToText(node.scene as import('../lib/chat/scene-utils.js').Scene | null, node.feeling)}${node.themes ? ` (themes: ${(node.themes as string[]).join(', ')})` : ''}`
+            }).filter(Boolean)
+            return { content: [{ type: 'text' as const, text: `記憶 ${lines.length}件（ベクトル検索）:\n${lines.join('\n')}` }] }
+          }
+          return { content: [{ type: 'text' as const, text: `「${args.query}」に関する記憶は見つかりませんでした。` }] }
+        }
+
+        // フォールバック: ilike検索（OPENAI_API_KEY未設定時）
         const nodes = await store.getNodes({
           actionQuery: args.query,
           limit,
@@ -97,7 +117,7 @@ export function createMcpServer(
         const lines = nodes.map(n =>
           `- [${n.id}] ${sceneToText(n.scene as import('../lib/chat/scene-utils.js').Scene | null, n.feeling)}${n.themes ? ` (themes: ${(n.themes as string[]).join(', ')})` : ''}`
         )
-        return { content: [{ type: 'text' as const, text: `記憶 ${nodes.length}件:\n${lines.join('\n')}` }] }
+        return { content: [{ type: 'text' as const, text: `記憶 ${nodes.length}件（キーワード検索）:\n${lines.join('\n')}` }] }
       } catch (err) {
         return { content: [{ type: 'text' as const, text: `error: ${String(err)}` }], isError: true }
       }

--- a/supabase/migrations/20260504_node_vector_search.sql
+++ b/supabase/migrations/20260504_node_vector_search.sql
@@ -1,0 +1,60 @@
+-- spec-946: ノードレベルベクトル検索
+-- 次元: 256 → 1536 統一
+-- memory_nodesにvectorカラム追加 + match_nodes RPC作成
+-- match_clusters RPCを1536次元に更新
+
+-- ノードvectorカラム追加
+ALTER TABLE memory_nodes ADD COLUMN IF NOT EXISTS vector vector(1536);
+CREATE INDEX IF NOT EXISTS idx_memory_nodes_vector ON memory_nodes USING ivfflat (vector vector_cosine_ops) WITH (lists = 100);
+
+-- クラスタvector次元変更（256 → 1536）
+-- 既存のベクトルはNULLクリアしてバックフィルで再計算
+ALTER TABLE clusters DROP COLUMN IF EXISTS vector;
+ALTER TABLE clusters ADD COLUMN vector vector(1536);
+CREATE INDEX IF NOT EXISTS idx_clusters_vector ON clusters USING ivfflat (vector vector_cosine_ops) WITH (lists = 100);
+
+-- match_nodes RPC（新規作成）
+CREATE OR REPLACE FUNCTION match_nodes(
+  p_user_id UUID,
+  query_embedding vector(1536),
+  match_threshold FLOAT DEFAULT 0.35,
+  match_count INT DEFAULT 5,
+  p_being_id UUID DEFAULT NULL
+)
+RETURNS TABLE (id UUID, cluster_id UUID, similarity FLOAT)
+LANGUAGE sql STABLE
+AS $$
+  SELECT mn.id, mn.cluster_id,
+    1 - (mn.vector <=> query_embedding) AS similarity
+  FROM memory_nodes mn
+  WHERE mn.user_id = p_user_id
+    AND mn.vector IS NOT NULL
+    AND mn.status = 'active'
+    AND (p_being_id IS NULL OR mn.being_id = p_being_id)
+    AND 1 - (mn.vector <=> query_embedding) > match_threshold
+  ORDER BY mn.vector <=> query_embedding
+  LIMIT match_count;
+$$;
+
+-- match_clusters RPCを1536次元に更新
+CREATE OR REPLACE FUNCTION match_clusters(
+  p_user_id UUID,
+  query_embedding vector(1536),
+  match_threshold FLOAT DEFAULT 0.45,
+  match_count INT DEFAULT 5,
+  p_being_id UUID DEFAULT NULL
+)
+RETURNS TABLE (id UUID, name TEXT, similarity FLOAT)
+LANGUAGE sql STABLE
+AS $$
+  SELECT clusters.id, clusters.name,
+    1 - (clusters.vector <=> query_embedding) AS similarity
+  FROM clusters
+  WHERE clusters.user_id = p_user_id
+    AND clusters.vector IS NOT NULL
+    AND (clusters.is_parent IS NULL OR clusters.is_parent = FALSE)
+    AND (p_being_id IS NULL OR clusters.being_id = p_being_id)
+    AND 1 - (clusters.vector <=> query_embedding) > match_threshold
+  ORDER BY clusters.vector <=> query_embedding
+  LIMIT match_count;
+$$;


### PR DESCRIPTION
## 概要

spec-946: クラスタレベルのベクトル検索からノードレベルへの移行。spec-29実験でノードレベルの方が想起精度が大幅に高いことが実証されたため。

Closes #946

## 変更内容

### embedding.ts
- `EXPECTED_DIM` 256 → 1536（text-embedding-3-smallのフル次元）
- `dimensions` パラメータ削除（1536はモデルデフォルト）
- `nodeToEmbedText(scene, feeling)` ヘルパー追加（when+action+feelingを結合）
- `recomputeClusterVector` も `nodeToEmbedText` を使うよう変更

### types.ts
- `MemoryStore` に3メソッド追加:
  - `findSimilarNodes(queryVector, topK?, threshold?)`
  - `updateNodeVector(nodeId, vector)`
  - `updateNodeVectors(updates[])`

### supabase-store.ts
- 上記3メソッドの実装（`match_nodes` RPC呼び出し）
- `findSimilarClusters` に `p_being_id` を渡すよう修正

### graph.ts
- embed対象を `action` → `nodeToEmbedText(when+action+feeling)` に変更
- `saveNodes` 後に `updateNodeVectors` でノードのvectorをDBに保存

### haiku-recall.ts
- `findSimilarClusters` → `findSimilarNodes` に切り替え
- top-3ノードを直接取得（クラスタ経由のノード取得をスキップ）
- 返却内容に `node_id` / `cluster_id` を追加（深掘り用）

### recall-tools.ts
- `recall_memory` ツールに `node_id` パラメータ追加
- `node_id` 指定時は特定ノードの詳細を返す（新機能）
- `cluster_id` は任意項目に変更

### mcp/server.ts
- `search_memory` をベクトル検索に変更
- OPENAI_API_KEY未設定時は ilike 検索にフォールバック
- 結果に `node_id`/`cluster_id` を含める

### supabase/migrations/20260504_node_vector_search.sql
- `memory_nodes.vector vector(1536)` カラム追加
- `clusters.vector` を 256 → 1536 に変更
- `match_nodes` RPC 新規作成
- `match_clusters` RPC を 1536 次元に更新

## 注意点

- 既存のクラスタベクトル検索（`findSimilarClusters`）は残存。巡回のクラスタ割付で引き続き使用
- マイグレーション実行後、既存ノード・クラスタのバックフィルが必要（vectorカラムNULL → 1536dim再計算）
- 次元変更はbreaking change。マイグレーション前に古い256dimベクトルはDROPされるため、バックフィル完了まで既存の類似検索は機能しない
