### PR TITLE
fix: support append/delete for partner_rules via update_memory tool

### DIFF
--- a/being-worker/src/lib/chat/update-memory.ts
+++ b/being-worker/src/lib/chat/update-memory.ts
@@ -21,6 +21,7 @@ export const UPDATE_MEMORY_TOOL = {
     'パートナーの記憶（preferences, knowledge, relationship, partner_tools, partner_map, diary, notes）を読み書きする。また、party_message targetでパーティメッセージを送信できる。\n\n' +
     'notes: ユーザーへのメモ・ノートを管理する。get=全件取得, append=新規追加, update=内容更新(key=id), delete=削除(key=id)\n\n' +
     '⚠️ souls / partner_rules の書き込みは、ユーザーが明示的に指示した場合のみ使用すること。\n\n' +
+    '⚠️ partner_rules append の content は「[category] title: 本文」形式で指定すること。例: 「[memory] 記録時の認知: actorsはシーンの実態を書く」\n\n' +
     '⚠️ update/delete 操作には必ず key を指定すること。key なしの update/delete は実行拒否されます。\n\n' +
     '【アクセス権限】このツールはユーザーの個人データにアクセスする。データはサービス提供目的のみに使用し、第三者提供はしない。ユーザーはデータの確認・修正・削除をいつでもリクエストできる。',
   input_schema: {
@@ -434,7 +435,33 @@ export async function handleUpdateMemory(
           return { success: true, message: `partner_rules[${key}] を更新しました` }
         }
 
-        return { success: false, message: `partner_rules の action ${action} は未対応です（追加・削除はUI経由）` }
+        if (action === 'append') {
+          if (!content) return { success: false, message: 'partner_rules append には content が必要です' }
+          // content 形式: [category] title: 本文
+          const m = content.match(/^\s*\[([^\]]+)\]\s*([^:]+?)\s*:\s*([\s\S]+)$/)
+          if (!m) {
+            return {
+              success: false,
+              message: 'partner_rules append の content は「[category] title: 本文」形式で指定してください',
+            }
+          }
+          const [, category, title, body] = m
+          const created = await store.addRule({
+            partnerType: pType,
+            category: category.trim(),
+            title: title.trim(),
+            content: body.trim(),
+          })
+          return { success: true, message: `partner_rules[${created.id}] を追加しました（${category.trim()}/${title.trim()}）` }
+        }
+
+        if (action === 'delete') {
+          if (!key) return { success: false, message: 'partner_rules delete には key（id）が必要です' }
+          await store.deleteRule(key)
+          return { success: true, message: `partner_rules[${key}] を削除しました` }
+        }
+
+        return { success: false, message: `partner_rules の action ${action} は未対応です` }
       }
 
       // ─── souls ──────────────────────────────────────

--- a/being-worker/src/lib/memory/supabase-store.ts
+++ b/being-worker/src/lib/memory/supabase-store.ts
@@ -1178,6 +1178,40 @@ export function createSupabaseMemoryStore(
       if (error) throw new Error(`updateRule failed: ${error.message}`)
     },
 
+    async addRule(input: {
+      partnerType: string
+      category: string
+      title: string
+      content: string
+      sortOrder?: number
+    }): Promise<PartnerRule> {
+      const row = {
+        user_id: userId,
+        ...(beingId ? { being_id: beingId } : {}),
+        partner_type: input.partnerType,
+        category: input.category,
+        title: input.title,
+        content: input.content,
+        sort_order: input.sortOrder ?? 100,
+        enabled: true,
+      }
+      const { data, error } = await supabase
+        .from('partner_rules')
+        .insert(row)
+        .select('id, partner_type, category, title, content, sort_order, enabled')
+        .single()
+      if (error) throw new Error(`addRule failed: ${error.message}`)
+      return data as PartnerRule
+    },
+
+    async deleteRule(id: string): Promise<void> {
+      const { error } = await supabase
+        .from('partner_rules')
+        .delete()
+        .eq('id', id)
+      if (error) throw new Error(`deleteRule failed: ${error.message}`)
+    },
+
     // ── profiles ──
 
     async getProfile(): Promise<Profile | null> {

--- a/being-worker/src/lib/memory/types.ts
+++ b/being-worker/src/lib/memory/types.ts
@@ -371,6 +371,14 @@ export interface MemoryStore {
   getRules(partnerType: string): Promise<PartnerRule[]>
   getAllRules(partnerType: string): Promise<PartnerRule[]>
   updateRule(id: string, patch: { content?: string; enabled?: boolean }): Promise<void>
+  addRule(input: {
+    partnerType: string
+    category: string
+    title: string
+    content: string
+    sortOrder?: number
+  }): Promise<PartnerRule>
+  deleteRule(id: string): Promise<void>
 
   // --- profiles ---
   getProfile(): Promise<Profile | null>


### PR DESCRIPTION
## 背景

`update_memory(target=partner_rules, action=append)` を呼んだ時、エラーで弾かれていた:

```
{"success":false,"message":"partner_rules の action append は未対応です（追加・削除はUI経由）"}
```

会話中にユーザーから「ルール追加して」と明示指示があった時、UI経由を案内するしかなく作業が分断される。`#468` の「ユーザーが明示的に指示した場合のみ」制約は維持した上で、ツール経由でも追加・削除できるようにする。

## 変更内容

### `MemoryStore` interface (types.ts)
- `addRule(input)` 追加
- `deleteRule(id)` 追加

### `supabase-store.ts`
- `addRule`: insert with `user_id` / `being_id` (beingIdがあればscope付き) / partner_type / category / title / content / sort_order
- `deleteRule`: delete by id
- 既存の `updateRule` と同じ構造を踏襲

### `update-memory.ts` (`partner_rules` case)
- `append`: content を `[category] title: 本文` 形式でパース → addRule
- `delete`: key (id) で deleteRule
- 形式不正なら明示的エラーメッセージ
- ツール説明文に append の content 形式を追記

## append の使い方

```
update_memory(
  target="partner_rules",
  action="append",
  content="[memory] 記録時の認知: actorsはシーンの実態を書く"
)
```

→ category=memory / title=記録時の認知 / content=actorsはシーンの実態を書く で挿入。sort_order=100 デフォルト、enabled=true、partnerTypeは現セッションのものを使う。

## #468 制約の維持

ツール説明文に以下の警告は維持:

> ⚠️ souls / partner_rules の書き込みは、ユーザーが明示的に指示した場合のみ使用すること。

## テスト

- `tsc --noEmit` 通過
- 既存テスト無し（`tests/` ディレクトリ未作成）のため自動テスト追加は今回スコープ外
- マージ後、Being Workerデプロイ→実際に append を叩いて動作確認したい

## 関連

- 起点: claude.aiセッション中、ひろきから「rulesにactors記録ルール書いて」指示 → append未対応で詰まった
- 既存制約 #468（ユーザー明示指示のみ）は維持